### PR TITLE
Allow logger to be overriden

### DIFF
--- a/lib/websocket/connection.litcoffee
+++ b/lib/websocket/connection.litcoffee
@@ -1,6 +1,6 @@
 
 	class SmackboneLive.WebsocketConnection extends Smackbone.Event
-		constructor: (@host) ->
+		constructor: (@host, @log) ->
 
 		connect: ->
 			@readyState = 0
@@ -29,5 +29,5 @@
 			@trigger 'close', this
 
 		_onError: (error) =>
-			console.error 'we have a error:', error
+			@log?.log 'we have a error:', error
 			@trigger 'error', this


### PR DESCRIPTION
So you can create a nice and quite `WebsocketConnection`

```js
new SmackboneLive.WebsocketConnection(host, null)
```